### PR TITLE
[Feature] - Networking formatting

### DIFF
--- a/Sources/HKLogger/Common/HKLoggerNetworking.swift
+++ b/Sources/HKLogger/Common/HKLoggerNetworking.swift
@@ -1,0 +1,144 @@
+//
+//  HKLoggerNetworking.swift
+//
+//
+//  Created by Alejandra on 3/4/23.
+//
+
+import Foundation
+
+struct HKLoggerNetworking: Codable {
+    let method: String
+    let path: String
+    let request: NetworkingRequest
+    let response: NetworkingResponse
+    
+    struct NetworkingRequest: Codable {
+        let headers: [String: String]?
+        let body: JSONValue?
+    }
+    
+    struct NetworkingResponse: Codable {
+        let statusCode: Int
+        let headers: [String: String]?
+        let body: JSONValue?
+    }
+}
+
+enum JSONValue: Codable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case dictionary([String: JSONValue])
+    case array([JSONValue])
+    case null
+    
+    init(from decoder: Decoder) throws {
+        if let value = try? decoder.singleValueContainer().decode(String.self) {
+            self = .string(value)
+        } else if let value = try? decoder.singleValueContainer().decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? decoder.singleValueContainer().decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? decoder.singleValueContainer().decode([String: JSONValue].self) {
+            self = .dictionary(value)
+        } else if let value = try? decoder.singleValueContainer().decode([JSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .null
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+      if let map = self.toAny() as? [String: Any] {
+        var container = encoder.container(keyedBy: JSONCodingKeys.self)
+        try encodeValue(fromObjectContainer: &container, map: map)
+      } else if let arr = self.toAny() as? [Any] {
+          var container = encoder.unkeyedContainer()
+          try encodeValue(fromArrayContainer: &container, arr: arr)
+      } else {
+        var container = encoder.singleValueContainer()
+
+        if let value = self.toAny() as? String {
+          try container.encode(value)
+        } else if let value = self.toAny() as? Int {
+          try container.encode(value)
+        } else if let value = self.toAny() as? Double {
+          try container.encode(value)
+        } else if let value = self.toAny() as? Bool {
+          try container.encode(value)
+        } else {
+          try container.encodeNil()
+        }
+      }
+    }
+    
+    func encodeValue(fromArrayContainer container: inout UnkeyedEncodingContainer, arr: [Any]) throws {
+      for value in arr {
+        if let value = value as? String {
+          try container.encode(value)
+        } else if let value = value as? Int {
+          try container.encode(value)
+        } else if let value = value as? Double {
+          try container.encode(value)
+        } else if let value = value as? Bool {
+          try container.encode(value)
+        } else if let value = value as? [String: Any] {
+          var keyedContainer = container.nestedContainer(keyedBy: JSONCodingKeys.self)
+          try encodeValue(fromObjectContainer: &keyedContainer, map: value)
+        } else if let value = value as? [Any] {
+          var unkeyedContainer = container.nestedUnkeyedContainer()
+          try encodeValue(fromArrayContainer: &unkeyedContainer, arr: value)
+        } else {
+          try container.encodeNil()
+        }
+      }
+    }
+    
+    func encodeValue(fromObjectContainer container: inout KeyedEncodingContainer<JSONCodingKeys>, map: [String:Any]) throws {
+      for k in map.keys {
+        let value = map[k]
+        let encodingKey = JSONCodingKeys(stringValue: k)
+
+        if let value = value as? String {
+          try container.encode(value, forKey: encodingKey)
+        } else if let value = value as? Int {
+          try container.encode(value, forKey: encodingKey)
+        } else if let value = value as? Double {
+          try container.encode(value, forKey: encodingKey)
+        } else if let value = value as? Bool {
+          try container.encode(value, forKey: encodingKey)
+        } else if let value = value as? [String: Any] {
+          var keyedContainer = container.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: encodingKey)
+          try encodeValue(fromObjectContainer: &keyedContainer, map: value)
+        } else if let value = value as? [Any] {
+          var unkeyedContainer = container.nestedUnkeyedContainer(forKey: encodingKey)
+          try encodeValue(fromArrayContainer: &unkeyedContainer, arr: value)
+        } else {
+          try container.encodeNil(forKey: encodingKey)
+        }
+      }
+    }
+}
+
+extension JSONValue {
+    
+    func toAny() -> Any {
+        switch self {
+        case .string(let value):
+            return value
+        case .number(let value):
+            return value
+        case .bool(let value):
+            return value
+        case .null:
+            return NSNull()
+        case .array(let values):
+            return values.map { $0.toAny() }
+        case .dictionary(let values):
+            return values.mapValues { $0.toAny() }
+        }
+    }
+    
+}
+ 

--- a/Sources/HKLogger/Common/HKLoggerNetworking.swift
+++ b/Sources/HKLogger/Common/HKLoggerNetworking.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct HKLoggerNetworking: Codable {
+internal struct HKLoggerNetworking: Codable {
     let method: String
     let path: String
-    let request: NetworkingRequest
-    let response: NetworkingResponse
+    let request: NetworkingRequest?
+    let response: NetworkingResponse?
     
     struct NetworkingRequest: Codable {
         let headers: [String: String]?
@@ -25,7 +25,7 @@ struct HKLoggerNetworking: Codable {
     }
 }
 
-enum JSONValue: Codable {
+internal enum JSONValue: Codable {
     case string(String)
     case number(Double)
     case bool(Bool)

--- a/Sources/HKLogger/Common/HKLoggerType.swift
+++ b/Sources/HKLogger/Common/HKLoggerType.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Logs type
 public enum HKLoggerType {
     case analytics
-    case networking(request: URLRequest, response: HTTPURLResponse, body: Data?)
+    case networking(request: URLRequest, response: HTTPURLResponse, responseBody: Data?)
     case trace
     case health
     case `default`
@@ -30,8 +30,8 @@ public extension HKLoggerType {
     /// Message generation to replace log message
     var message: String? {
         switch self {
-        case .networking(let request, let response, let body):
-            return getMessageFor(request: request, response: response, body: body)
+        case .networking(let request, let response, let responseBody):
+            return getMessageFor(request: request, response: response, responseBody: responseBody)
         default:
             return nil
         }
@@ -39,31 +39,43 @@ public extension HKLoggerType {
 }
 
 private extension HKLoggerType {
-    func getMessageFor(request: URLRequest, response: HTTPURLResponse, body: Data?) -> String? {
+    func getMessageFor(request: URLRequest, response: HTTPURLResponse, responseBody: Data?) -> String? {
         let method = request.httpMethod ?? ""
         let path = request.url?.absoluteString ?? ""
-        let requestBody = request.httpBody?.toJSONValue
-        let requestHeaders = request.allHTTPHeaderFields?.asJSONDictionary
-        let responseHeaders = response.allHeaderFields as? [String: String]
-        let responseBody = body?.toJSONValue
-        
-        let logRequest = HKLoggerNetworking.NetworkingRequest(
-            headers: requestHeaders,
-            body: requestBody
-        )
-        let logResponse = HKLoggerNetworking.NetworkingResponse(
-            statusCode: response.statusCode,
-            headers: responseHeaders,
-            body: responseBody
-        )
         
         let networking = HKLoggerNetworking(
             method: method,
             path: path,
-            request: logRequest,
-            response: logResponse
+            request: getNetworkingRequest(for: request),
+            response: getNetworkingResponse(for: response, with: responseBody)
         )
-
+        
         return networking.asJSON
+    }
+    
+    func getNetworkingRequest(for request: URLRequest) -> HKLoggerNetworking.NetworkingRequest? {
+        let body = request.httpBody?.toJSONValue
+        let headers = request.allHTTPHeaderFields?.asJSONDictionary
+        
+        if headers == nil && body == nil {
+            return nil
+        } else {
+            return HKLoggerNetworking.NetworkingRequest(
+                headers: headers,
+                body: body
+            )
+        }
+    }
+    
+    func getNetworkingResponse(for response: HTTPURLResponse, with body: Data?) -> HKLoggerNetworking.NetworkingResponse? {
+        let headers = response.allHeaderFields as? [String: String]
+        let responseBody = body?.toJSONValue
+        let statusCode = response.statusCode
+        
+        return HKLoggerNetworking.NetworkingResponse(
+            statusCode: statusCode,
+            headers: headers?.isEmpty == true ? nil : headers,
+            body: responseBody
+        )
     }
 }

--- a/Sources/HKLogger/Common/HKLoggerType.swift
+++ b/Sources/HKLogger/Common/HKLoggerType.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Logs type
 public enum HKLoggerType {
     case analytics
-    case networking
+    case networking(request: URLRequest, response: HTTPURLResponse, body: Data?)
     case trace
     case health
     case `default`
@@ -27,4 +27,43 @@ public extension HKLoggerType {
         }
     }
     
+    /// Message generation to replace log message
+    var message: String? {
+        switch self {
+        case .networking(let request, let response, let body):
+            return getMessageFor(request: request, response: response, body: body)
+        default:
+            return nil
+        }
+    }
+}
+
+private extension HKLoggerType {
+    func getMessageFor(request: URLRequest, response: HTTPURLResponse, body: Data?) -> String? {
+        let method = request.httpMethod ?? ""
+        let path = request.url?.absoluteString ?? ""
+        let requestBody = request.httpBody?.toJSONValue
+        let requestHeaders = request.allHTTPHeaderFields?.asJSONDictionary
+        let responseHeaders = response.allHeaderFields as? [String: String]
+        let responseBody = body?.toJSONValue
+        
+        let logRequest = HKLoggerNetworking.NetworkingRequest(
+            headers: requestHeaders,
+            body: requestBody
+        )
+        let logResponse = HKLoggerNetworking.NetworkingResponse(
+            statusCode: response.statusCode,
+            headers: responseHeaders,
+            body: responseBody
+        )
+        
+        let networking = HKLoggerNetworking(
+            method: method,
+            path: path,
+            request: logRequest,
+            response: logResponse
+        )
+
+        return networking.asJSON
+    }
 }

--- a/Sources/HKLogger/HKLogger.swift
+++ b/Sources/HKLogger/HKLogger.swift
@@ -135,7 +135,8 @@ internal extension HKLogger {
         _ functionName: StaticString = #function,
         _ lineNumber: Int = #line
     ) -> Bool {
-        let logMessage = getLogMessageForConsole(message, severity, type, fileName, functionName, lineNumber)
+        var formattedMessage = getFormattedMessageIfNeeded(for: type, message: message)
+        let logMessage = getLogMessageForConsole(formattedMessage, severity, type, fileName, functionName, lineNumber)
         switch environment {
         case .debug:
             print(logMessage)
@@ -161,7 +162,8 @@ internal extension HKLogger {
         
         
         do {
-            let logMessage = "\(getLogMessageForFile(message, severity, type, fileName, functionName, lineNumber))\n"
+            var formattedMessage = getFormattedMessageIfNeeded(for: type, message: message)
+            let logMessage = "\(getLogMessageForFile(formattedMessage, severity, type, fileName, functionName, lineNumber))\n"
             
             if saveLogsToFile {
                 try writeFile(in: logsPath, message: logMessage)
@@ -289,4 +291,12 @@ internal extension HKLogger {
         return lastIndex
     }
     
+    func getFormattedMessageIfNeeded(for type: HKLoggerType, message: String) -> String {
+        switch type {
+        case .networking:
+            return type.message ?? message
+        default:
+            return message
+        }
+    }
 }

--- a/Sources/HKLogger/Utilities/Data+JSON.swift
+++ b/Sources/HKLogger/Utilities/Data+JSON.swift
@@ -1,0 +1,14 @@
+//
+//  Data+JSON.swift
+//  
+//
+//  Created by Alejandra on 19/4/23.
+//
+
+import Foundation
+
+extension Data {
+    var toJSONValue: JSONValue? {
+        return try? JSONDecoder().decode(JSONValue.self, from: self)
+    }
+}

--- a/Sources/HKLogger/Utilities/Encodable+JSON.swift
+++ b/Sources/HKLogger/Utilities/Encodable+JSON.swift
@@ -1,0 +1,39 @@
+//
+//  Encodable+JSON.swift
+//
+//
+//  Created by Alejandra on 4/4/23.
+//
+
+import Foundation
+
+extension Encodable {
+    var asJSONDictionary: [String: String]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        var json: [String: String]?
+        do {
+            json = try JSONSerialization.jsonObject(
+                with: data,
+                options: [.fragmentsAllowed]
+            ) as? [String: String]
+        } catch {
+            print("AS DICTIONARY ERROR: \(String(describing: error))")
+        }
+        return json
+    }
+    
+    var asJSON: String {
+        let jsonEncoder = JSONEncoder()
+        
+        jsonEncoder.outputFormatting = [.withoutEscapingSlashes, .prettyPrinted]
+        guard let encodedData = try? jsonEncoder.encode(self)
+        else {
+            return ""
+        }
+        
+        let jsonString = String(data: encodedData,
+                                encoding: .utf8)
+        
+        return jsonString ?? ""
+    }
+}

--- a/Sources/HKLogger/Utilities/JSONCodingKeys.swift
+++ b/Sources/HKLogger/Utilities/JSONCodingKeys.swift
@@ -1,0 +1,23 @@
+//
+//  JSONCodingKeys.swift
+//
+//
+//  Created by Alejandra on 19/4/23.
+//
+
+import Foundation
+
+struct JSONCodingKeys: CodingKey {
+    var stringValue: String
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    var intValue: Int?
+
+    init?(intValue: Int) {
+        self.init(stringValue: "\(intValue)")
+        self.intValue = intValue
+    }
+}

--- a/Sources/HKLogger/Utilities/KeyedDecodingContainer+Utils.swift
+++ b/Sources/HKLogger/Utilities/KeyedDecodingContainer+Utils.swift
@@ -1,0 +1,41 @@
+//
+//  KeyedDecodingContainer+Utils.swift
+//
+//
+//  Created by Alejandra on 19/4/23.
+//
+
+import Foundation
+
+extension KeyedDecodingContainer {
+    func decode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {
+        let container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        return try container.decode(type)
+    }
+
+    func decode(_ type: [Any].Type, forKey key: K) throws -> [Any] {
+        var container = try self.nestedUnkeyedContainer(forKey: key)
+        return try container.decode(type)
+    }
+
+    func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        var dictionary = [String: Any]()
+
+        for key in allKeys {
+            if let boolValue = try? decode(Bool.self, forKey: key) {
+                dictionary[key.stringValue] = boolValue
+            } else if let stringValue = try? decode(String.self, forKey: key) {
+                dictionary[key.stringValue] = stringValue
+            } else if let intValue = try? decode(Int.self, forKey: key) {
+                dictionary[key.stringValue] = intValue
+            } else if let doubleValue = try? decode(Double.self, forKey: key) {
+                dictionary[key.stringValue] = doubleValue
+            } else if let nestedDictionary = try? decode([String: Any].self, forKey: key) {
+                dictionary[key.stringValue] = nestedDictionary
+            } else if let nestedArray = try? decode([Any].self, forKey: key) {
+                dictionary[key.stringValue] = nestedArray
+            }
+        }
+        return dictionary
+    }
+}

--- a/Sources/HKLogger/Utilities/KeyedEncodingContainerProtocol+Utils.swift
+++ b/Sources/HKLogger/Utilities/KeyedEncodingContainerProtocol+Utils.swift
@@ -37,16 +37,22 @@ extension KeyedEncodingContainerProtocol where Key == JSONCodingKeys {
 
 extension KeyedEncodingContainerProtocol {
     mutating func encode(_ value: [String: Any]?, forKey key: Key) throws {
-        if value != nil {
-            var container = self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
-            try container.encode(value!)
+        guard let value = value
+        else {
+            throw EncodingError.invalidValue(value as Any, EncodingError.Context(codingPath: codingPath + [key], debugDescription: "Invalid JSON value"))
         }
+        
+        var container = self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        try container.encode(value)
     }
-
+    
     mutating func encode(_ value: [Any]?, forKey key: Key) throws {
-        if value != nil {
-            var container = self.nestedUnkeyedContainer(forKey: key)
-            try container.encode(value!)
+        guard let value = value
+        else {
+            throw EncodingError.invalidValue(value as Any, EncodingError.Context(codingPath: codingPath + [key], debugDescription: "Invalid JSON value"))
         }
+        
+        var container = self.nestedUnkeyedContainer(forKey: key)
+        try container.encode(value)
     }
 }

--- a/Sources/HKLogger/Utilities/KeyedEncodingContainerProtocol+Utils.swift
+++ b/Sources/HKLogger/Utilities/KeyedEncodingContainerProtocol+Utils.swift
@@ -1,0 +1,52 @@
+//
+//  KeyedEncodingContainerProtocol+Utils.swift
+//
+//
+//  Created by Alejandra on 19/4/23.
+//
+
+import Foundation
+
+extension KeyedEncodingContainerProtocol where Key == JSONCodingKeys {
+    mutating func encode(_ value: [String: Any]) throws {
+        try value.forEach({ (key, value) in
+            let key = JSONCodingKeys(stringValue: key)
+            switch value {
+            case let value as Bool:
+                try encode(value, forKey: key)
+            case let value as Int:
+                try encode(value, forKey: key)
+            case let value as String:
+                try encode(value, forKey: key)
+            case let value as Double:
+                try encode(value, forKey: key)
+            case let value as CGFloat:
+                try encode(value, forKey: key)
+            case let value as [String: Any]:
+                try encode(value, forKey: key)
+            case let value as [Any]:
+                try encode(value, forKey: key)
+            case Optional<Any>.none:
+                try encodeNil(forKey: key)
+            default:
+                throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: codingPath + [key], debugDescription: "Invalid JSON value"))
+            }
+        })
+    }
+}
+
+extension KeyedEncodingContainerProtocol {
+    mutating func encode(_ value: [String: Any]?, forKey key: Key) throws {
+        if value != nil {
+            var container = self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+            try container.encode(value!)
+        }
+    }
+
+    mutating func encode(_ value: [Any]?, forKey key: Key) throws {
+        if value != nil {
+            var container = self.nestedUnkeyedContainer(forKey: key)
+            try container.encode(value!)
+        }
+    }
+}

--- a/Sources/HKLogger/Utilities/UnkeyedDecodingContainer+Utils.swift
+++ b/Sources/HKLogger/Utilities/UnkeyedDecodingContainer+Utils.swift
@@ -1,0 +1,40 @@
+//
+//  UnkeyedDecodingContainer+Utils.swift
+//
+//
+//  Created by Alejandra on 19/4/23.
+//
+
+import Foundation
+
+extension UnkeyedDecodingContainer {
+    mutating func decode(_ type: [Any].Type) throws -> [Any] {
+        var array: [Any] = []
+        
+        while isAtEnd == false {
+            let value: String? = try decode(String?.self)
+            if value == nil {
+                continue
+            }
+            if let value = try? decode(Bool.self) {
+                array.append(value)
+            } else if let value = try? decode(Int.self) {
+                array.append(value)
+            } else if let value = try? decode(Double.self) {
+                array.append(value)
+            } else if let value = try? decode(String.self) {
+                array.append(value)
+            } else if let nestedDictionary = try? decode([String: Any].self) {
+                array.append(nestedDictionary)
+            } else if let nestedArray = try? decode([Any].self) {
+                array.append(nestedArray)
+            }
+        }
+        return array
+    }
+    
+    mutating func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        let nestedContainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self)
+        return try nestedContainer.decode(type)
+    }
+}

--- a/Sources/HKLogger/Utilities/UnkeyedEncodingContainer+Utils.swift
+++ b/Sources/HKLogger/Utilities/UnkeyedEncodingContainer+Utils.swift
@@ -1,0 +1,41 @@
+//
+//  UnkeyedEncodingContainer+Utils.swift
+//
+//
+//  Created by Alejandra on 19/4/23.
+//
+
+import Foundation
+
+extension UnkeyedEncodingContainer {
+    mutating func encode(_ value: [Any]) throws {
+        try value.enumerated().forEach({ (index, value) in
+            switch value {
+            case let value as Bool:
+                try encode(value)
+            case let value as Int:
+                try encode(value)
+            case let value as String:
+                try encode(value)
+            case let value as Double:
+                try encode(value)
+            case let value as CGFloat:
+                try encode(value)
+            case let value as [String: Any]:
+                try encode(value)
+            case let value as [Any]:
+                try encode(value)
+            case Optional<Any>.none:
+                try encodeNil()
+            default:
+                let keys = JSONCodingKeys(intValue: index).map({ [ $0 ] }) ?? []
+                throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: codingPath + keys, debugDescription: "Invalid JSON value"))
+            }
+        })
+    }
+    
+    mutating func encode(_ value: [String: Any]) throws {
+        var nestedContainer = self.nestedContainer(keyedBy: JSONCodingKeys.self)
+        try nestedContainer.encode(value)
+    }
+}

--- a/Tests/HKLogger-Tests/HKLoggerFileTests.swift
+++ b/Tests/HKLogger-Tests/HKLoggerFileTests.swift
@@ -177,8 +177,14 @@ extension HKLoggerFileTests {
     func testDebugLogMessageWithMetaData() throws {
         logger.includeMetadataOnFile = true
         let logMessage = "Testing Debug message with MetaData"
-        let expectedValue = "[DEBUG] [NETWORKING] [main] [HKLoggerFileTests.swift] [testDebugLogMessageWithMetaData()] [Line 181]: \(logMessage)\(logger.endingCharacter)\n"
-        try logger.saveLogsToFileIfNeeded(logMessage, .debug, .networking)
+        let formattedMessage = getFormattedNetworkingMessage()
+        let expectedValue = "[DEBUG] [NETWORKING] [main] [HKLoggerFileTests.swift] [testDebugLogMessageWithMetaData()] [Line 183]: \(formattedMessage)\(logger.endingCharacter)\n"
+        let urlRequest = getURLRequest()
+        try logger.saveLogsToFileIfNeeded(logMessage, .debug, .networking(
+            request: urlRequest,
+            response: HTTPURLResponse(),
+            body: nil
+        ))
         
         let fileURL = URL(string: "\(logger.logsPath!)_1.log")!
         
@@ -267,5 +273,30 @@ private extension HKLoggerFileTests {
         if FileManager.default.fileExists(atPath: logFilePath) {
             try? FileManager.default.removeItem(atPath: logFilePath)
         }
+    }
+    
+    func getURLRequest() -> URLRequest {
+        let url = URL(string: "https://www.google.com")
+        return URLRequest(url: url!)
+    }
+    
+    // DO NOT CHANGE THE FORMAT OF THIS JSON OR IT WILL MAKE THE TEST FAIL
+    func getFormattedNetworkingMessage() -> String {
+        let formattedMessage = """
+        {
+      "path" : "https://www.google.com",
+      "method" : "GET",
+      "response" : {
+        "headers" : {
+
+        },
+        "statusCode" : 200
+      },
+      "request" : {
+
+      }
+    }
+    """
+        return formattedMessage.trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Tests/HKLogger-Tests/HKLoggerFileTests.swift
+++ b/Tests/HKLogger-Tests/HKLoggerFileTests.swift
@@ -183,7 +183,7 @@ extension HKLoggerFileTests {
         try logger.saveLogsToFileIfNeeded(logMessage, .debug, .networking(
             request: urlRequest,
             response: HTTPURLResponse(),
-            body: nil
+            responseBody: nil
         ))
         
         let fileURL = URL(string: "\(logger.logsPath!)_1.log")!
@@ -196,6 +196,28 @@ extension HKLoggerFileTests {
         }
         
         clearFiles()
+    }
+    
+    func testMessageGeneration() {
+        var type = HKLoggerType.networking(
+            request: getURLRequest(),
+            response: HTTPURLResponse(),
+            responseBody: nil
+        )
+        
+        XCTAssertEqual(type.message, getFormattedNetworkingMessage())
+        
+        type = .default
+        XCTAssertNil(type.message)
+        
+        type = .analytics
+        XCTAssertNil(type.message)
+        
+        type = .health
+        XCTAssertNil(type.message)
+        
+        type = .trace
+        XCTAssertNil(type.message)
     }
     
 }
@@ -287,13 +309,7 @@ private extension HKLoggerFileTests {
       "path" : "https://www.google.com",
       "method" : "GET",
       "response" : {
-        "headers" : {
-
-        },
         "statusCode" : 200
-      },
-      "request" : {
-
       }
     }
     """


### PR DESCRIPTION
## Overview
- The `Networking` type now receives a `URLRequest` for the request, `HTTPURLResponse` for the response, and `Data` for the response body.
- The networking message is now automatically generated using the data passed as parameters. This new message replaces the message sent by the client.
- The message is generated by creating a `HKLoggerNetworking` model and then encoding it to a `JSON` String.


## Pull Request checker
Make sure you've checked all the following items.
- [x] You've assigned the PR to yourself
- [x] You've requested at least two reviewers
- [x] You've set the correct labels (`bugfix`, `enhancement`, `feature`, etc.)
- [x] You've manually run all tests (if there are any)
