### PR TITLE
[Bugfix] - Fix save logs in host when running the app on physical device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,155 @@
+# Created by https://www.gitignore.io/api/swift,xcode,fastlane,objective-c
+# Edit at https://www.gitignore.io/?templates=swift,xcode,fastlane,objective-c
+
+### fastlane ###
+# fastlane - A streamlined workflow tool for Cocoa deployment
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+# fastlane specific
+fastlane/report.xml
+.fastlane/report.xml
+
+# deliver temporary files
+fastlane/Preview.html
+.fastlane/Preview.html
+
+# snapshot generated screenshots
+fastlane/screenshots/**/*.png
+fastlane/screenshots/screenshots.html
+
+.fastlane/screenshots/**/*.png
+.fastlane/screenshots/screenshots.html
+
+# scan temporary files
+fastlane/test_output
+
+### Objective-C ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Objective-C Patch ###
+
+### Swift ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+Packages/
+Package.pins
+Package.resolved
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/*
+!*.xcworkspace/contents.xcworkspacedata
+!*.xcworkspace/xcuserdata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+*/xcuserdata/*
+
+# End of https://www.gitignore.io/api/swift,xcode,fastlane,objective-c
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ logger.saveLogsToHost = true
 logger.hostLogsDirectory = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(".logs")
 ```
 
-Besides, if you are running your app on a physical device, it's mandatory to run the script in the `Scripts` folder **on the host Mac**. Due to the sandbox environment, it's necessary to establish a connection between the device and the host Mac itself.
+Besides, if you are running your app on a physical device, it's mandatory to run the script in the `Scripts` folder **on the host Mac**. In order to run it, execute the following command in any console: `swift ClientScript.swift`. Due to the sandbox environment, it's necessary to establish a connection between the device and the host Mac itself.
 ​
 ## Contribution
 If you want to report a bug or need a new feature, open an issue from the issues tab.

--- a/README.md
+++ b/README.md
@@ -72,24 +72,28 @@ let logger = HKLogger.shared
 logger.includeMetadataOnConsole = false
 logger.includeMetadataOnFile = true
 logger.environment = .debug
-logger.saveLogsToFile = truex
+logger.saveLogsToFile = true
 logger.logsDirectoryName = URL(string: "TestingLogs.log")
 ​
 do {
     try logger.log(message: "Testing \(logger.logsDirectoryName?.path)", severity: .info, type: .health)
 } catch let loggerError as HKLoggerError {
-   print(loggerError.debugMessage)
+    print(loggerError.debugMessage)
 } catch {
-   print(error)
+    print(error)
 }
 ```
+
+#### Save the logs file to the host's machine
 ​
+​In case you want to additionally save the logs in the host's machine, you have to define a few more settings:
 ```swift
-// If you want to save the logs file to the host's machine you will need to provide the full path
 logger.saveLogsToHost = true
 // Warning: The directory path must not contain any spaces!
 logger.hostLogsDirectory = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(".logs")
 ```
+
+Besides, if you are running your app on a physical device, it's mandatory to run the script in the `Scripts` folder **on the host Mac**. Due to the sandbox environment, it's necessary to establish a connection between the device and the host Mac itself.
 ​
 ## Contribution
-If you want to report a bug or need a new feature, open an issue from the issues tab
+If you want to report a bug or need a new feature, open an issue from the issues tab.

--- a/Scripts/ClientScript.swift
+++ b/Scripts/ClientScript.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Network
+
+struct LogData: Decodable {
+    let path: String
+    let fileName: String
+    let message: String
+    let deviceInfo: String?
+    let createNewFile: Bool
+}
+
+/// Connects this with a specific server, in order to receive its messages
+class Connection {
+
+    var connection: NWConnection?
+    let endpoint: NWEndpoint?
+
+    init(endpoint: NWEndpoint) {
+        self.endpoint = endpoint
+        
+        connection = NWConnection(to: endpoint, using: getParameters())
+        start()
+    }
+    
+    func getParameters() -> NWParameters {
+        let tcpOptions = NWProtocolTCP.Options()
+        tcpOptions.enableKeepalive = true
+        tcpOptions.keepaliveIdle = 2
+
+        let parameters = NWParameters(tls: nil, tcp: tcpOptions)
+        parameters.includePeerToPeer = true
+        
+        return parameters
+    }
+
+    func start() {
+        guard let connection = connection else {
+            return
+        }
+        
+        connection.stateUpdateHandler = { newState in
+            print("Connection state update: \(newState)")
+            switch newState {
+            case .ready:
+                self.receiveMessage()
+            case .failed(let error):
+                print("\(connection) failed with \(error)")
+
+                /// Cancel the connection upon a failure.
+                connection.cancel()
+                
+                if self.endpoint != nil && error == NWError.posix(.ECONNABORTED) {
+                    /// Reconnect if the user suspends the app on the nearby device.
+                    let newConnection = NWConnection(to: (self.endpoint)!, using: self.getParameters())
+                    self.connection = newConnection
+                    self.start()
+                }
+            case .cancelled:
+                self.connection = nil
+            default:
+                break
+            }
+        }
+        connection.start(queue: .main)
+    }
+
+    func receiveMessage() {
+        guard let connection = connection else {
+            return
+        }
+        
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 100000) { data, context, isComplete, _ in
+            if let data = data,
+               let decodedData = try? JSONDecoder().decode(LogData.self, from: data) {
+                let message = decodedData.message
+                print("Connection received message: \(message)")
+                
+                self.processData(for: decodedData)
+            }
+            self.receiveMessage()
+        }
+    }
+    
+    func processData(for data: LogData) {
+        guard let pathURL = URL(string: data.path) else { return }
+        
+        do {
+            let lastIndex = findLastFileIndex(for: pathURL, fileName: data.fileName)
+            let currentPath = "\(pathURL.path)_\(data.createNewFile ? lastIndex + 1 : lastIndex).log"
+            
+            if FileManager.default.fileExists(atPath: currentPath) {
+                
+                guard let url = URL(string: currentPath) else { return }
+                let fh = try FileHandle(forWritingTo: url)
+                fh.seekToEndOfFile()
+                try fh.write(contentsOf: Data(data.message.utf8))
+                fh.closeFile()
+                
+            } else {
+                let logfilePath = "\(data.path)_1.log"
+                
+                var message = data.message
+                if let deviceInfo = data.deviceInfo {
+                    message.insert(contentsOf: deviceInfo, at: message.startIndex)
+                }
+                
+                try message.write(toFile: logfilePath, atomically: true, encoding: .utf8)
+            }
+        } catch {
+            print("Error saving the log file: \(error)")
+        }
+    }
+    
+    func findLastFileIndex(for path: URL, fileName: String) -> Int {
+        var lastIndex = 1
+        let fm = FileManager.default
+        let directoryPath = path.deletingLastPathComponent().path
+        var isDir: ObjCBool = true
+        
+        if fm.fileExists(atPath: directoryPath, isDirectory: &isDir) {
+            let files = try! fm.contentsOfDirectory(atPath: directoryPath)
+            
+            for name in files {
+                if name.hasPrefix("\(fileName)_"),
+                   let stringIndex = name.split(separator: "_").last?.prefix(while: { $0.isNumber }),
+                   let index = Int(stringIndex),
+                   index > lastIndex {
+                    lastIndex = index
+                }
+            }
+        }
+        
+        return lastIndex
+    }
+
+}
+
+/// Discover server for the type specified
+class Browser {
+
+    let browser: NWBrowser
+
+    init() {
+        let parameters = NWParameters()
+        parameters.includePeerToPeer = true
+
+        browser = NWBrowser(for: .bonjour(type: "_hklogger._tcp", domain: nil), using: parameters)
+    }
+
+    func start(handler: @escaping (NWBrowser.Result) -> Void) {
+        browser.stateUpdateHandler = { newState in
+            print("Browser state update: \(newState)")
+            
+            switch newState {
+            case .failed(let error):
+                print("Browser failed with \(error), restarting...")
+                self.browser.cancel()
+                self.start(handler: handler)
+            default:
+                break
+            }
+        }
+        browser.browseResultsChangedHandler = { results, changes in
+            for result in results {
+                if case NWEndpoint.service = result.endpoint {
+                    handler(result)
+                }
+            }
+        }
+        browser.start(queue: .main)
+    }
+}
+
+/// Client class to initialize the browser and keep the connection with the server
+class Client {
+
+    let browser = Browser()
+
+    var connection: Connection?
+
+    func start() {
+        browser.start { [weak self] result in
+            print("Client handler result: \(result)")
+            self?.connection = Connection(endpoint: result.endpoint)
+        }
+    }
+
+}
+
+let client = Client()
+client.start()
+
+RunLoop.current.run()

--- a/Sources/HKLogger/HostConnection/Connection.swift
+++ b/Sources/HKLogger/HostConnection/Connection.swift
@@ -1,0 +1,56 @@
+//
+//  File.swift
+//  
+//
+//  Created by Martín Lago on 25/4/23.
+//
+
+import Foundation
+import Network
+
+class Connection {
+
+    var connection: NWConnection?
+
+    init(connection: NWConnection) {
+        self.connection = connection
+        start()
+    }
+
+    func start() {
+        guard let connection = connection else {
+            return
+        }
+        
+        connection.stateUpdateHandler = { newState in
+            print("Connection state update: \(newState)")
+            switch newState {
+            case .failed:
+                connection.cancel()
+                self.connection = nil
+                NotificationCenter.default.post(name: .connectionCancelled, object: nil)
+            default:
+                break
+            }
+        }
+        connection.start(queue: .main)
+    }
+
+    func send(_ data: LogData) {
+        guard let connection = connection else {
+            return
+        }
+        
+        guard let encodedData = try? JSONEncoder().encode(data) else { return }
+        
+        connection.send(
+            content: encodedData,
+            contentContext: .defaultMessage,
+            isComplete: true,
+            completion: .contentProcessed({ message in
+                print("Send message completion: \(String(describing: message))")
+            })
+        )
+    }
+    
+}

--- a/Sources/HKLogger/HostConnection/LogData.swift
+++ b/Sources/HKLogger/HostConnection/LogData.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Martín Lago on 25/4/23.
+//
+
+import Foundation
+
+struct LogData: Encodable {
+    let path: String
+    let fileName: String
+    let message: String
+    var deviceInfo: String? = nil
+    var createNewFile: Bool = false
+}

--- a/Sources/HKLogger/HostConnection/Notification.swift
+++ b/Sources/HKLogger/HostConnection/Notification.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Martín Lago on 2/5/23.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let connectionCancelled = Notification.Name("ConnectionCancelled")
+}

--- a/Sources/HKLogger/HostConnection/Server.swift
+++ b/Sources/HKLogger/HostConnection/Server.swift
@@ -1,0 +1,89 @@
+//
+//  File.swift
+//  
+//
+//  Created by Martín Lago on 25/4/23.
+//
+
+import Foundation
+import Network
+
+class Server {
+
+    var listener: NWListener?
+
+    var connection: Connection?
+
+    init() throws {
+        configureListener()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(cancelConnection),
+            name: .connectionCancelled,
+            object: nil
+        )
+    }
+    
+    func configureListener() {
+        let tcpOptions = NWProtocolTCP.Options()
+        tcpOptions.enableKeepalive = true
+        tcpOptions.keepaliveIdle = 2
+
+        let parameters = NWParameters(tls: nil, tcp: tcpOptions)
+        parameters.includePeerToPeer = true
+        
+        do {
+            listener = try NWListener(using: parameters)
+        } catch {
+            print("Error creating listener: \(error)")
+        }
+        
+        listener?.service = NWListener.Service(name: "server", type: "_hklogger._tcp")
+    }
+
+    func start() {
+        guard let listener = listener else {
+            return
+        }
+        
+        listener.stateUpdateHandler = { newState in
+            switch newState {
+            case .ready:
+                print("Listener ready: \(newState)")
+            case .failed(let error):
+                print("Listener failed with: \(error)")
+                listener.cancel()
+                self.listener = nil
+                self.connection = nil
+                self.configureListener()
+                self.start()
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] newConnection in
+            guard let self = self,
+                  self.connection == nil
+            else {
+                newConnection.cancel()
+                return
+            }
+            
+            print("Listener -  New connection: \(newConnection)")
+            let connection = Connection(connection: newConnection)
+            self.connection = connection
+        }
+        listener.start(queue: .main)
+    }
+    
+    @objc func cancelConnection() {
+        connection = nil
+    }
+
+    func send(_ data: LogData) {
+        guard let connection = connection else { return }
+        connection.send(data)
+    }
+    
+}


### PR DESCRIPTION
## Overview
Due to the sandbox it was impossible to save the logs file on the host mac, when running the app on a physical device. It was implemented a solution using the `Network` framework and Bonjour, in order to establish a TCP connection between the device and the mac itself, which allows to send and receive messages between them. The mac script was added under the `Scripts` folder, and also the readme file was updated taking into account this.


## Pull Request checker
Make sure you've checked all the following items.
- [X] You've assigned the PR to yourself
- [X] You've requested at least two reviewers
- [X] You've set the correct labels (`bugfix`, `enhancement`, `feature`, etc.)
- [X] You've manually run all tests (if there are any)
