### PR TITLE
[Feature] - Network interceptor

### DIFF
--- a/Sources/HKLogger/Documentation.docc/GettingStarted.md
+++ b/Sources/HKLogger/Documentation.docc/GettingStarted.md
@@ -101,3 +101,12 @@ extension AppDelegate {
     }
 }
 ```
+If you wish HKLogger to log `URLRequest` and `HTTPURLResponse` automatically for you, then add the following flag and create a a `URLSession` using the given session configuration.
+
+```swift
+logger.includeNetworkLogs = true
+```
+
+```swift
+let session = URLSession(configuration: logger.sessionConfig ?? .default)
+```

--- a/Sources/HKLogger/HKLogger.swift
+++ b/Sources/HKLogger/HKLogger.swift
@@ -37,6 +37,16 @@ public final class HKLogger {
     public var includeMetadataOnConsole = false
     /// Indicates if the metadata should be included in the file's messages
     public var includeMetadataOnFile = false
+    ///Indicates if the log should listen and generate messages based on requests and responses
+    public var includeNetworkLogs = false {
+        didSet {
+            setupNetworkLogs()
+        }
+    }
+    /// Returns the session configuration to be used on the URLSession. It's available only if `includeNetworkLogs` is active
+    public private(set) var sessionConfig: URLSessionConfiguration?
+    
+    
     
     // MARK: - Private properties
     internal var logDeviceInfo = true
@@ -101,19 +111,6 @@ public final class HKLogger {
             printMessageIfNeeded(error.localizedDescription, .error, .default, fileName, functionName, lineNumber)
         }
     }
-    
-    /// Start monitoring network requests and responses
-    public func startLoggingFromNetwork() -> URLSession? {
-        if URLProtocol.registerClass(HKLoggerUrlProtocol.self) {
-            let configuration = URLSessionConfiguration.default
-            configuration.protocolClasses = [HKLoggerUrlProtocol.self]
-            let session = URLSession(
-            return configuration
-        }
-        
-        return nil
-    }
-    
 }
 
 // MARK: - Life Cycle Config
@@ -220,6 +217,20 @@ internal extension HKLogger {
             
         } catch {
             throw HKLoggerError.couldNotSaveToFile(logMessage: error.localizedDescription)
+        }
+    }
+    
+    func setupNetworkLogs() {
+        guard includeNetworkLogs == true
+        else {
+            sessionConfig = nil
+            return
+        }
+        
+        if URLProtocol.registerClass(HKLoggerUrlProtocol.self) {
+            let configuration = URLSessionConfiguration.default
+            configuration.protocolClasses = [HKLoggerUrlProtocol.self]
+            sessionConfig = configuration
         }
     }
 }

--- a/Sources/HKLogger/HKLogger.swift
+++ b/Sources/HKLogger/HKLogger.swift
@@ -101,6 +101,19 @@ public final class HKLogger {
             printMessageIfNeeded(error.localizedDescription, .error, .default, fileName, functionName, lineNumber)
         }
     }
+    
+    /// Start monitoring network requests and responses
+    public func startLoggingFromNetwork() -> URLSession? {
+        if URLProtocol.registerClass(HKLoggerUrlProtocol.self) {
+            let configuration = URLSessionConfiguration.default
+            configuration.protocolClasses = [HKLoggerUrlProtocol.self]
+            let session = URLSession(
+            return configuration
+        }
+        
+        return nil
+    }
+    
 }
 
 // MARK: - Life Cycle Config

--- a/Sources/HKLogger/HKLogger.swift
+++ b/Sources/HKLogger/HKLogger.swift
@@ -37,7 +37,7 @@ public final class HKLogger {
     public var includeMetadataOnConsole = false
     /// Indicates if the metadata should be included in the file's messages
     public var includeMetadataOnFile = false
-    ///Indicates if the log should listen and generate messages based on requests and responses
+    ///Indicates if the logger should listen and generate messages based on requests and responses
     public var includeNetworkLogs = false {
         didSet {
             setupNetworkLogs()

--- a/Sources/HKLogger/NetworkInterceptor/HKLoggerUrlProtocol.swift
+++ b/Sources/HKLogger/NetworkInterceptor/HKLoggerUrlProtocol.swift
@@ -11,34 +11,32 @@ class HKLoggerUrlProtocol: URLProtocol {
     var session: URLSession?
     var sessionTask: URLSessionDataTask?
     
-    var response: HTTPURLResponse?
-    
-//    override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
-//        super.init(request: request, cachedResponse: cachedResponse, client: client)
-//
-//        if session == nil {
-//            session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-//        }
-//    }
-//
-//
-//    override class func canInit(with request: URLRequest) -> Bool {
-//        return true
-//    }
-//
-//    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-//        return request
-//    }
-//
-//    override func startLoading() {
-//        sessionTask = session?.dataTask(with: request as URLRequest)
-//        sessionTask?.resume()
-//    }
-//
-//    override func stopLoading() {
-//        sessionTask?.cancel()
-//        session?.invalidateAndCancel()
-//    }
+    override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
+        super.init(request: request, cachedResponse: cachedResponse, client: client)
+
+        if session == nil {
+            session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        }
+    }
+
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        sessionTask = session?.dataTask(with: request as URLRequest)
+        sessionTask?.resume()
+    }
+
+    override func stopLoading() {
+        sessionTask?.cancel()
+        session?.invalidateAndCancel()
+    }
 }
 
 extension HKLoggerUrlProtocol: URLSessionDataDelegate {

--- a/Sources/HKLogger/NetworkInterceptor/HKLoggerUrlProtocol.swift
+++ b/Sources/HKLogger/NetworkInterceptor/HKLoggerUrlProtocol.swift
@@ -1,0 +1,105 @@
+//
+//  File.swift
+//  
+//
+//  Created by Juan Rodríguez HK on 18/5/23.
+//
+
+import Foundation
+
+class HKLoggerUrlProtocol: URLProtocol {
+    var session: URLSession?
+    var sessionTask: URLSessionDataTask?
+    
+    var response: HTTPURLResponse?
+    
+//    override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
+//        super.init(request: request, cachedResponse: cachedResponse, client: client)
+//
+//        if session == nil {
+//            session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+//        }
+//    }
+//
+//
+//    override class func canInit(with request: URLRequest) -> Bool {
+//        return true
+//    }
+//
+//    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+//        return request
+//    }
+//
+//    override func startLoading() {
+//        sessionTask = session?.dataTask(with: request as URLRequest)
+//        sessionTask?.resume()
+//    }
+//
+//    override func stopLoading() {
+//        sessionTask?.cancel()
+//        session?.invalidateAndCancel()
+//    }
+}
+
+extension HKLoggerUrlProtocol: URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+     
+        if let response = dataTask.response as? HTTPURLResponse {
+            HKLogger.shared.log(
+                message: "HKLogger - Network",
+                severity: .debug,
+                type: .networking(
+                    request: self.request,
+                    response: response,
+                    responseBody: data
+                )
+            )
+        }
+        
+        
+        client?.urlProtocol(self, didLoad: data)
+    }
+    
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        let policy = URLCache.StoragePolicy(rawValue: request.cachePolicy.rawValue) ?? .notAllowed
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: policy)
+        completionHandler(.allow)
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+        client?.urlProtocol(self, wasRedirectedTo: request, redirectResponse: response)
+        completionHandler(request)
+    }
+    
+    func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        guard let error = error else { return }
+        client?.urlProtocol(self, didFailWithError: error)
+    }
+    
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let protectionSpace = challenge.protectionSpace
+        let sender = challenge.sender
+        
+        if protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+            if let serverTrust = protectionSpace.serverTrust {
+                let credential = URLCredential(trust: serverTrust)
+                sender?.use(credential, for: challenge)
+                completionHandler(.useCredential, credential)
+                return
+            }
+        }
+    }
+    
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    
+}


### PR DESCRIPTION
## Overview
* New flag added to allow the user intercept requests and responses through `URLProtocol and `URLSessionDataDelegate`.
* New variable exposes which contains the `URLSessionConfiguration` ready to be used in the networking layer


## Pull Request checker
Make sure you've checked all the following items.
- [x] You've assigned the PR to yourself
- [x] You've requested at least two reviewers
- [x] You've set the correct labels (`bugfix`, `enhancement`, `feature`, etc.)
- [x] You've manually run all tests (if there are any)
